### PR TITLE
57 support many device type for device

### DIFF
--- a/apps/discovery/src/discovery/discovery.service.ts
+++ b/apps/discovery/src/discovery/discovery.service.ts
@@ -55,16 +55,19 @@ export class DiscoveryService {
     }
   }
 
-  private getDeviceTypeByToken(token: string): Promise<DeviceTypeEntity | null> {
+  private async getDeviceTypeByToken(token: string): Promise<DeviceTypeEntity | null> {
+    let de: DeviceTypeEntity | null = null;
     if (this.isNum(token)) {
       const id = parseInt(token, 10);
-      return this.deviceTypeRepo.findOne({ where: { id } });
+      de = await this.deviceTypeRepo.findOne({ where: { id } });
     } else {
-      return this.deviceTypeRepo.findOne({ where: { name: token } });
+      de = await this.deviceTypeRepo.findOne({ where: { name: token } });
     }
+    if (!de) this.logger.warn(`Device type not found for token: ${token}`);
+    return de;
   }
 
-  async setDeviceContext(dto: DiscoveryMessageV2Dto, parent?: DeviceEntity) {
+  async setDeviceContext(dto: DiscoveryMessageV2Dto, parent?: DeviceEntity): Promise<DeviceEntity> {
     let device = await this.deviceRepo.findOne({ where: { ID: dto.id } })
       ?? this.deviceRepo.create({ ...dto.general?.physicalDevice, ID: dto.id });
 
@@ -80,7 +83,7 @@ export class DiscoveryService {
     if (dto.platform) device.platform = await this.getPlatformByToken(dto.platform.token) ?? undefined
     if (dto.deviceTypeToken) {
       const deviceTypes = await Promise.all(
-        dto.deviceTypeToken.split(",").map(t => this.getDeviceTypeByToken(t))
+        dto.deviceTypeToken.split(",").map(t => this.getDeviceTypeByToken(t.trim()))
       );
       device.deviceType = deviceTypes.filter((dt): dt is DeviceTypeEntity => dt !== null);
     }

--- a/apps/discovery/src/discovery/discovery.service.ts
+++ b/apps/discovery/src/discovery/discovery.service.ts
@@ -46,7 +46,7 @@ export class DiscoveryService {
   private isNum = (num) => Number.isFinite ? Number.isFinite(+num) : isFinite(+num)
 
   private getPlatformByToken(token: string): Promise<PlatformEntity | null> {
-    
+
     if (this.isNum(token)) {
       const id = parseInt(token, 10);
       return this.platformRepo.findOne({ where: { id } });
@@ -78,7 +78,12 @@ export class DiscoveryService {
     device.formations = dto?.softwareData?.formations;
 
     if (dto.platform) device.platform = await this.getPlatformByToken(dto.platform.token) ?? undefined
-    if (dto.deviceTypeToken) device.deviceType = await this.getDeviceTypeByToken(dto.deviceTypeToken) ?? undefined
+    if (dto.deviceTypeToken) {
+      const deviceTypes = await Promise.all(
+        dto.deviceTypeToken.split(",").map(t => this.getDeviceTypeByToken(t))
+      );
+      device.deviceType = deviceTypes.filter((dt): dt is DeviceTypeEntity => dt !== null);
+    }
 
     // Only device there is no of type platform, can be a device children
     if (!dto.platform) { device.parent = parent } else { device.parent = undefined }

--- a/libs/common/src/database/entities/device.entity.ts
+++ b/libs/common/src/database/entities/device.entity.ts
@@ -83,6 +83,10 @@ export class DeviceEntity {
   // })
   // platforms: PlatformEntity[];
 
+  /**
+   * @deprecated This field is deprecated and will be removed in the future
+   */
+  @Deprecated()
   @Column("text", { name: "formations", array: true, nullable: true })
   formations?: string[];
 

--- a/libs/common/src/database/entities/device.entity.ts
+++ b/libs/common/src/database/entities/device.entity.ts
@@ -5,6 +5,7 @@ import { DeviceComponentEntity } from "./device-component-state.entity";
 import { PlatformEntity } from "./platform.entity";
 import { ReleaseEntity } from "./release.entity";
 import { DeviceTypeEntity } from "./device-type.entity";
+import { Deprecated } from "../../decorators";
 
 @Entity("device")
 export class DeviceEntity {
@@ -25,9 +26,13 @@ export class DeviceEntity {
   @JoinColumn({ name: "platform_id" })
   platform?: PlatformEntity;
 
-  @ManyToOne(() => DeviceTypeEntity, { nullable: true, eager: true, onUpdate: "CASCADE", onDelete: "SET NULL" })
-  @JoinColumn({ name: "device_type_id" })
-  deviceType?: DeviceTypeEntity;
+  @ManyToMany(() => DeviceTypeEntity, { eager: true })
+  @JoinTable({
+    name: "device_device_types",
+    joinColumn: { name: "device_id", referencedColumnName: "ID" },
+    inverseJoinColumn: { name: "device_type_id", referencedColumnName: "id" },
+  })
+  deviceType?: DeviceTypeEntity[];
 
   @Column({ nullable: true })
   name?: string;

--- a/libs/common/src/database/migration/1756717531369-DeviceAndDeviceType_ManyToMany.ts
+++ b/libs/common/src/database/migration/1756717531369-DeviceAndDeviceType_ManyToMany.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DeviceAndDeviceTypeManyToMany1756717531369 implements MigrationInterface {
+    name = 'DeviceAndDeviceTypeManyToMany1756717531369'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "device" DROP CONSTRAINT "FK_9aa8fcca6a2f86b2638c02fd1bd"`);
+        await queryRunner.query(`CREATE TABLE "device_device_types" ("device_id" character varying NOT NULL, "device_type_id" integer NOT NULL, CONSTRAINT "PK_970ed25ed30f21bc7c0f3185852" PRIMARY KEY ("device_id", "device_type_id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_5c265468ec777c19f42308c769" ON "device_device_types" ("device_id") `);
+        await queryRunner.query(`CREATE INDEX "IDX_c57b3ee1596e9a00008da082ba" ON "device_device_types" ("device_type_id") `);
+        await queryRunner.query(`ALTER TABLE "device" DROP COLUMN "device_type_id"`);
+        await queryRunner.query(`ALTER TABLE "device_device_types" ADD CONSTRAINT "FK_5c265468ec777c19f42308c769b" FOREIGN KEY ("device_id") REFERENCES "device"("ID") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "device_device_types" ADD CONSTRAINT "FK_c57b3ee1596e9a00008da082ba1" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "device_device_types" DROP CONSTRAINT "FK_c57b3ee1596e9a00008da082ba1"`);
+        await queryRunner.query(`ALTER TABLE "device_device_types" DROP CONSTRAINT "FK_5c265468ec777c19f42308c769b"`);
+        await queryRunner.query(`ALTER TABLE "device" ADD "device_type_id" integer`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_c57b3ee1596e9a00008da082ba"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_5c265468ec777c19f42308c769"`);
+        await queryRunner.query(`DROP TABLE "device_device_types"`);
+        await queryRunner.query(`ALTER TABLE "device" ADD CONSTRAINT "FK_9aa8fcca6a2f86b2638c02fd1bd" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE SET NULL ON UPDATE CASCADE`);
+    }
+
+}

--- a/libs/common/src/dto/device/dto/device-org.dto.ts
+++ b/libs/common/src/dto/device/dto/device-org.dto.ts
@@ -74,7 +74,7 @@ export class DeviceOrgDto {
 
     // Org type relation    
     device.platformName = deviceE?.platform?.name;
-    device.deviceTypeName = deviceE?.deviceType?.name;
+    device.deviceTypeName = deviceE?.deviceType?.map(dt => dt.name).join(", ");
 
     return device
   }

--- a/libs/common/src/dto/device/dto/device.dto.ts
+++ b/libs/common/src/dto/device/dto/device.dto.ts
@@ -117,7 +117,7 @@ export class DeviceDto {
 
     // Org type relation    
     device.platformName = deviceE?.platform?.name;
-    device.deviceTypeName = deviceE?.deviceType?.name;
+    device.deviceTypeName = deviceE?.deviceType?.map(dt => dt.name).join(", ");
 
     return device
   }

--- a/libs/common/src/dto/discovery/dto/discovery-message.dto.ts
+++ b/libs/common/src/dto/discovery/dto/discovery-message.dto.ts
@@ -57,7 +57,6 @@ export class DiscoveryMessageV2Dto {
     required: false,
     description: 'Timestamp when the discovery snapshot was taken',
     type: String, // Important for Swagger to document this as a string
-    example: new Date(),
   })
   @IsOptional()
   @IsDate()

--- a/libs/common/src/dto/discovery/dto/discovery-software.dto.ts
+++ b/libs/common/src/dto/discovery/dto/discovery-software.dto.ts
@@ -143,7 +143,11 @@ export class ComponentStateDto {
 
 export class DiscoverySoftwareV2Dto {
 
-  @ApiProperty({ required: false })
+  /**
+   * @deprecated This field is deprecated and will be removed in the future. use instead platform object in the root object
+   */
+  @Deprecated()
+  @ApiProperty({ required: false, deprecated: true })
   @IsString({ each: true })
   @IsNotEmpty({ each: true })
   @IsArray()


### PR DESCRIPTION
This pull request introduces a significant change to the device data model, allowing devices to be associated with multiple device types instead of just one. The migration updates the database schema, and the codebase is refactored to support this new many-to-many relationship. Additionally, some fields are marked as deprecated to prepare for future removals.

**Device Type Relationship Refactor:**

* Changed the `deviceType` property in `DeviceEntity` from a single `DeviceTypeEntity` (many-to-one) to an array of `DeviceTypeEntity` (many-to-many), including the necessary join table configuration. (`libs/common/src/database/entities/device.entity.ts`)
* Added a migration to create the new `device_device_types` join table, remove the old foreign key, and update relevant indexes and constraints. (`libs/common/src/database/migration/1756717531369-DeviceAndDeviceType_ManyToMany.ts`)
* Updated the device context logic in `DiscoveryService` to support multiple device type tokens, splitting and resolving each token, and assigning an array of device types to a device. (`apps/discovery/src/discovery/discovery.service.ts`) [[1]](diffhunk://#diff-809b1fa0ea73b6fb2144fbbf6f23a10e9e2a15bcac2b182f3919d854af0db1c3L58-R70) [[2]](diffhunk://#diff-809b1fa0ea73b6fb2144fbbf6f23a10e9e2a15bcac2b182f3919d854af0db1c3L81-R89)
* Updated DTOs (`DeviceDto`, `DeviceOrgDto`) to display all associated device type names as a comma-separated string. (`libs/common/src/dto/device/dto/device.dto.ts`, `libs/common/src/dto/device/dto/device-org.dto.ts`) [[1]](diffhunk://#diff-c308f6b5911dcd9feeb7cdc65282113f98fd535f7402e1621792153fe1087f24L120-R120) [[2]](diffhunk://#diff-7f39520d494b2b61acc851450970846be0fd5182bb60a8424db7873a73f366b2L77-R77)

**Deprecation and Documentation:**

* Marked the `formations` field in `DeviceEntity` and `DiscoverySoftwareV2Dto` as deprecated, and added deprecation documentation to encourage migration to new structures. (`libs/common/src/database/entities/device.entity.ts`, `libs/common/src/dto/discovery/dto/discovery-software.dto.ts`) [[1]](diffhunk://#diff-e2cac3fb94c3f597f910a771a5493a27e982e4d2a8ea569bb1161ad93159e66dR86-R89) [[2]](diffhunk://#diff-0f6b89da8ac78976778fea0d7055e994dfcc113c25fa7c43194002eb79a76ea5L146-R150)

These changes collectively enable devices to support multiple types and prepare the codebase for future improvements and removals.