### PR TITLE
59 generate token for device type and platform

### DIFF
--- a/apps/discovery/src/hierarchy/hierarchy.service.ts
+++ b/apps/discovery/src/hierarchy/hierarchy.service.ts
@@ -61,7 +61,7 @@ export class HierarchyService implements ProjectAccessService {
     } catch (error) {
       this.logger.error(`Error while saving platform: ${error}`);
       if (error.code === '23505') { // Unique constraint violation error code for PostgreSQL
-        throw new ConflictException('Platform name already exists');
+        throw AppErrorException.conflict(ErrorCode.DEVICE_PLATFORM_ALREADY_EXISTS, `Platform name '${dto.name}' already exists`);
       }
       throw error;
     }
@@ -72,7 +72,7 @@ export class HierarchyService implements ProjectAccessService {
     const platform = await this.platformRepo.findOneBy({ id: params.platformId });
     if (!platform) {
       this.logger.warn(`Platform with id ${params.platformId} not found`);
-      throw new NotFoundException('Platform not found');
+      throw AppErrorException.notFound(ErrorCode.DEVICE_PLATFORM_NOT_FOUND, `Platform: ${params.platformId} not found`);
     }
     return PlatformDto.fromEntity(platform);
   }
@@ -88,7 +88,7 @@ export class HierarchyService implements ProjectAccessService {
     this.logger.debug(`Update platform: ${dto.id}`);
     const platform = await this.platformRepo.findOneBy({ id: dto.id });
     if (!platform) {
-      throw new NotFoundException('Platform not found');
+      throw AppErrorException.notFound(ErrorCode.DEVICE_PLATFORM_NOT_FOUND, `Platform: ${dto.id} not found`);
     }
     Object.assign(platform, dto);
     try {
@@ -97,7 +97,7 @@ export class HierarchyService implements ProjectAccessService {
     } catch (error) {
       this.logger.error(`Error while saving platform: ${error}`);
       if (error.code === '23505') { // Unique constraint violation error code for PostgreSQL
-        throw new ConflictException('Platform name already exists');
+        throw AppErrorException.conflict(ErrorCode.DEVICE_PLATFORM_ALREADY_EXISTS, `Platform name '${dto.name}' already exists`);
       }
       throw error;
     }
@@ -109,7 +109,7 @@ export class HierarchyService implements ProjectAccessService {
     this.logger.debug(`Delete platform: ${params.platformId}`);
     const platform = await this.platformRepo.findOneBy({ id: params.platformId });
     if (!platform) {
-      throw new NotFoundException('Platform not found');
+      throw AppErrorException.notFound(ErrorCode.DEVICE_PLATFORM_NOT_FOUND, `Platform: ${params.platformId} not found`);
     }
     await this.platformRepo.remove(platform);
     return `Platform ${params.platformId} deleted successfully`;
@@ -156,7 +156,7 @@ export class HierarchyService implements ProjectAccessService {
     } catch (error) {
       this.logger.error(`Error while saving device type: ${error}`);
       if (error.code === '23505') {
-        throw AppErrorException.conflict(ErrorCode.DT_ALREADY_EXISTS, error);
+        throw AppErrorException.conflict(ErrorCode.DEVICE_DT_ALREADY_EXISTS, error);
       }
       throw error;
     }
@@ -167,7 +167,7 @@ export class HierarchyService implements ProjectAccessService {
     this.logger.debug(`Get device type: ${params.deviceTypeId}`);
     const deviceType = await this.deviceTypeRepo.findOneBy({ id: params.deviceTypeId });
     if (!deviceType) {
-      throw AppErrorException.notFound(ErrorCode.DT_NOT_FOUND, `Device type: ${params.deviceTypeId} not found`);
+      throw AppErrorException.notFound(ErrorCode.DEVICE_DT_NOT_FOUND, `Device type: ${params.deviceTypeId} not found`);
     }
     return DeviceTypeDto.fromEntity(deviceType);
   }
@@ -184,7 +184,7 @@ export class HierarchyService implements ProjectAccessService {
     this.logger.debug(`Update device type: ${dto.id}`);
     const deviceType = await this.deviceTypeRepo.findOneBy({ id: dto.id });
     if (!deviceType) {
-      throw new NotFoundException('Device type not found');
+      throw AppErrorException.notFound(ErrorCode.DEVICE_DT_NOT_FOUND, `Device type: ${dto.id} not found`);
     }
     Object.assign(deviceType, dto);
     try {
@@ -193,7 +193,7 @@ export class HierarchyService implements ProjectAccessService {
     } catch (error) {
       this.logger.error(`Error while saving device type: ${error}`);
       if (error.code === '23505') {
-        throw new ConflictException('Device type name already exists');
+        throw AppErrorException.conflict(ErrorCode.DEVICE_DT_ALREADY_EXISTS, `Device type name '${dto.name}' already exists`);
       }
       throw error;
     }
@@ -205,7 +205,7 @@ export class HierarchyService implements ProjectAccessService {
     this.logger.debug(`Delete device type: ${params.deviceTypeId}`);
     const deviceType = await this.deviceTypeRepo.findOneBy({ id: params.deviceTypeId });
     if (!deviceType) {
-      throw new NotFoundException('Device type not found');
+      throw AppErrorException.notFound(ErrorCode.DEVICE_DT_NOT_FOUND, `Device type: ${params.deviceTypeId} not found`);
     }
     await this.deviceTypeRepo.remove(deviceType);
     return `Device type ${params.deviceTypeId} deleted successfully`;
@@ -220,7 +220,7 @@ export class HierarchyService implements ProjectAccessService {
     });
 
     if (!platform) {
-      throw new NotFoundException(`Platform: '${params.platformId}' not found`);
+      throw AppErrorException.notFound(ErrorCode.DEVICE_PLATFORM_NOT_FOUND, `Platform: '${params.platformId}' not found`);
     }
 
     return PlatformHierarchyDto.fromPlatformEntity(platform);
@@ -234,7 +234,7 @@ export class HierarchyService implements ProjectAccessService {
       select: { projects: { id: true, name: true, projectName: true, label: { id: true, name: true } } }
     });
     if (!deviceType) {
-      throw new NotFoundException(`Device type: '${params.deviceTypeId}' not found`);
+      throw AppErrorException.notFound(ErrorCode.DEVICE_DT_NOT_FOUND, `Device type: '${params.deviceTypeId}' not found`);
     }
     return DeviceTypeHierarchyDto.fromDeviceTypeEntity(deviceType);
   }

--- a/apps/discovery/src/hierarchy/hierarchy.service.ts
+++ b/apps/discovery/src/hierarchy/hierarchy.service.ts
@@ -1,9 +1,11 @@
 import { DeviceTypeEntity, MemberProjectEntity, PlatformEntity, ProjectEntity } from "@app/common/database/entities";
 import { CreateDeviceTypeDto, CreatePlatformDto, DeviceTypeDto, DeviceTypeHierarchyDto, DeviceTypeParams, DeviceTypeProjectParams, PlatformDeviceTypeParams, PlatformDto, PlatformHierarchyDto, PlatformParams, UpdateDeviceTypeDto, UpdatePlatformDto } from "@app/common/dto/devices-hierarchy";
+import { AppErrorException, ErrorCode } from "@app/common/dto/error";
 import { ProjectAccessService } from "@app/common/utils/project-access";
 import { ConflictException, ForbiddenException, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import { InjectRepository } from "@nestjs/typeorm";
+import { createHash } from "crypto";
 import { ILike, Repository } from "typeorm";
 
 
@@ -110,7 +112,20 @@ export class HierarchyService implements ProjectAccessService {
     if (exists) {
       throw new ConflictException(`Device type name: "${dto.name}" already exists`);
     }
+
+    // Hash name to generate a numeric ID, then ensure uniqueness
+    const hashNameToId = (name: string): number => {
+      const hash = createHash('sha256').update(name).digest();
+      return hash.readUInt32BE(0) % 100_000_000;
+    };
+
+    let id = hashNameToId(dto.name);
+    while (await this.deviceTypeRepo.findOneBy({ id })) {
+      id = (id + 1) % 100_000_000;
+    }
+
     const deviceType = new DeviceTypeEntity();
+    deviceType.id = id;
     deviceType.name = dto.name;
     deviceType.description = dto.description;
     deviceType.os = dto.os;
@@ -129,7 +144,7 @@ export class HierarchyService implements ProjectAccessService {
     } catch (error) {
       this.logger.error(`Error while saving device type: ${error}`);
       if (error.code === '23505') {
-        throw new ConflictException('Device type name already exists');
+        throw AppErrorException.conflict(ErrorCode.DT_ALREADY_EXISTS, error);
       }
       throw error;
     }
@@ -140,7 +155,7 @@ export class HierarchyService implements ProjectAccessService {
     this.logger.debug(`Get device type: ${params.deviceTypeId}`);
     const deviceType = await this.deviceTypeRepo.findOneBy({ id: params.deviceTypeId });
     if (!deviceType) {
-      throw new NotFoundException(`Device type: ${params.deviceTypeId} not found`);
+      throw AppErrorException.notFound(ErrorCode.DT_NOT_FOUND, `Device type: ${params.deviceTypeId} not found`);
     }
     return DeviceTypeDto.fromEntity(deviceType);
   }

--- a/apps/discovery/src/hierarchy/hierarchy.service.ts
+++ b/apps/discovery/src/hierarchy/hierarchy.service.ts
@@ -30,7 +30,19 @@ export class HierarchyService implements ProjectAccessService {
       throw new ConflictException(`Platform name: "${dto.name}" already exists`);
     }
 
+    // Hash name to generate a numeric ID, then ensure uniqueness
+    const hashNameToId = (name: string): number => {
+      const hash = createHash('sha256').update(name).digest();
+      return hash.readUInt32BE(0) % 100_000_000;
+    };
+
+    let id = hashNameToId(dto.name);
+    while (await this.platformRepo.findOneBy({ id })) {
+      id = (id + 1) % 100_000_000;
+    }
+
     const platform = new PlatformEntity();
+    platform.id = id;
     platform.name = dto.name;
     platform.description = dto.description;
     platform.os = dto.os;

--- a/libs/common/src/database/entities/device-type.entity.ts
+++ b/libs/common/src/database/entities/device-type.entity.ts
@@ -1,4 +1,4 @@
-import { Column, CreateDateColumn, Entity, JoinTable, ManyToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, CreateDateColumn, Entity, JoinTable, ManyToMany, PrimaryColumn, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { PlatformEntity } from "./platform.entity";
 import { ProjectEntity } from "./project.entity";
 import { CPUArchitecture, DiskType, NetworkType, OS } from "./enums.entity";
@@ -6,7 +6,7 @@ import { CPUArchitecture, DiskType, NetworkType, OS } from "./enums.entity";
 @Entity("device_type")
 export class DeviceTypeEntity {
 
-  @PrimaryGeneratedColumn()
+  @PrimaryColumn({ type: "integer"})
   id: number
 
   @Column({ name: "name", unique: true })

--- a/libs/common/src/database/entities/platform.entity.ts
+++ b/libs/common/src/database/entities/platform.entity.ts
@@ -5,7 +5,7 @@ import { DeviceTypeEntity } from "./device-type.entity";
 @Entity("platform")
 export class PlatformEntity {
 
-  @PrimaryGeneratedColumn()
+  @PrimaryColumn({ type: 'integer' })
   id: number
 
   @Column({ name: "name", unique: true })

--- a/libs/common/src/database/migration/1756818420639-ChabgeDevieTypeIDColType.ts
+++ b/libs/common/src/database/migration/1756818420639-ChabgeDevieTypeIDColType.ts
@@ -1,0 +1,86 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ChabgeDevieTypeIDColType1756818420639 implements MigrationInterface {
+    name = 'ChabgeDevieTypeIDColType1756818420639'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // 1️⃣ Drop foreign keys & index
+        await queryRunner.query(`ALTER TABLE "device_device_types" DROP CONSTRAINT "FK_c57b3ee1596e9a00008da082ba1"`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" DROP CONSTRAINT "FK_86a2e27320d8434d971ea976a5e"`);
+        await queryRunner.query(`ALTER TABLE "device_type_project" DROP CONSTRAINT "FK_459a69eb47cc1ab5f664822af0e"`);
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" DROP CONSTRAINT "FK_7affc26f7561a1329f6da0c9ec1"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_08b61b07472247dc03568280b8"`);
+
+        // 2️⃣ Prepare for ID change
+        await queryRunner.query(`ALTER TABLE "device_type" ALTER COLUMN "id" DROP DEFAULT`);
+        await queryRunner.query(`DROP SEQUENCE IF EXISTS "device_type_id_seq"`);
+        await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pgcrypto`);
+
+        // 3️⃣ Add temporary column to keep old IDs
+        await queryRunner.query(`ALTER TABLE "device_type" ADD COLUMN "old_id" bigint`);
+        await queryRunner.query(`UPDATE "device_type" SET old_id = id`);
+
+        // 4️⃣ Update device_type.id with new hashed values
+        await queryRunner.query(`UPDATE "device_type" SET id = (((('x' || substr(encode(digest(name::text, 'sha256'), 'hex'), 1, 8))::bit(32)::bigint) & 4294967295) % 100000000)`);
+
+        // 5️⃣ Update all child tables to new IDs
+        await queryRunner.query(`UPDATE "device_type_project" dtp SET device_type_id = dt.id FROM "device_type" dt WHERE dtp.device_type_id = dt.old_id`);
+        await queryRunner.query(`UPDATE "platform_device_type" pdt SET device_type_id = dt.id FROM "device_type" dt WHERE pdt.device_type_id = dt.old_id`);
+        await queryRunner.query(`UPDATE "device_device_types" ddt SET device_type_id = dt.id FROM "device_type" dt WHERE ddt.device_type_id = dt.old_id`);
+        await queryRunner.query(`UPDATE "offering_tree_policy" otp SET device_type_id = dt.id FROM "device_type" dt WHERE otp.device_type_id = dt.old_id`);
+
+        // 6️⃣ Drop temporary column
+        await queryRunner.query(`ALTER TABLE "device_type" DROP COLUMN "old_id"`);
+
+        // 7️⃣ Recreate indexes
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_08b61b07472247dc03568280b8" ON "offering_tree_policy" ("platform_id", "device_type_id", "project_id")`);
+
+        // 8️⃣ Recreate foreign keys
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" ADD CONSTRAINT "FK_7affc26f7561a1329f6da0c9ec1" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "device_type_project" ADD CONSTRAINT "FK_459a69eb47cc1ab5f664822af0e" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" ADD CONSTRAINT "FK_86a2e27320d8434d971ea976a5e" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE NO ACTION ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "device_device_types" ADD CONSTRAINT "FK_c57b3ee1596e9a00008da082ba1" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // 1️⃣ Drop foreign keys & index
+        await queryRunner.query(`ALTER TABLE "device_device_types" DROP CONSTRAINT "FK_c57b3ee1596e9a00008da082ba1"`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" DROP CONSTRAINT "FK_86a2e27320d8434d971ea976a5e"`);
+        await queryRunner.query(`ALTER TABLE "device_type_project" DROP CONSTRAINT "FK_459a69eb47cc1ab5f664822af0e"`);
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" DROP CONSTRAINT "FK_7affc26f7561a1329f6da0c9ec1"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_08b61b07472247dc03568280b8"`);
+
+        // 2️⃣ Add temporary column to keep old hashed IDs
+        await queryRunner.query(`ALTER TABLE "device_type" ADD COLUMN "old_id" bigint`);
+        await queryRunner.query(`UPDATE "device_type" SET old_id = id`);
+
+        // 3️⃣ Reset device_type.id with new auto-increment values
+        await queryRunner.query(`DROP SEQUENCE IF EXISTS "device_type_id_seq"`);
+        await queryRunner.query(`CREATE SEQUENCE "device_type_id_seq" START 1`);
+        await queryRunner.query(`WITH cte AS (SELECT id AS old_id, ROW_NUMBER() OVER (ORDER BY old_id) AS rn FROM "device_type") UPDATE "device_type" dt SET id = cte.rn FROM cte WHERE dt.id = cte.old_id`);
+
+        // 4️⃣ Update sequence to match max ID
+        await queryRunner.query(`SELECT setval('device_type_id_seq', (SELECT MAX(id) FROM "device_type"))`);
+
+        // 5️⃣ Update all child tables to new IDs
+        await queryRunner.query(`UPDATE "device_type_project" dtp SET device_type_id = dt.id FROM "device_type" dt WHERE dtp.device_type_id = dt.old_id`);
+        await queryRunner.query(`UPDATE "platform_device_type" pdt SET device_type_id = dt.id FROM "device_type" dt WHERE pdt.device_type_id = dt.old_id`);
+        await queryRunner.query(`UPDATE "device_device_types" ddt SET device_type_id = dt.id FROM "device_type" dt WHERE ddt.device_type_id = dt.old_id`);
+        await queryRunner.query(`UPDATE "offering_tree_policy" otp SET device_type_id = dt.id FROM "device_type" dt WHERE otp.device_type_id = dt.old_id`);
+
+        // 6️⃣ Drop temporary column
+        await queryRunner.query(`ALTER TABLE "device_type" DROP COLUMN "old_id"`);
+
+        // 7️⃣ Recreate indexes
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_08b61b07472247dc03568280b8" ON "offering_tree_policy" ("platform_id", "device_type_id", "project_id")`);
+
+        // 8️⃣ Recreate foreign keys
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" ADD CONSTRAINT "FK_7affc26f7561a1329f6da0c9ec1" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "device_type_project" ADD CONSTRAINT "FK_459a69eb47cc1ab5f664822af0e" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" ADD CONSTRAINT "FK_86a2e27320d8434d971ea976a5e" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "device_device_types" ADD CONSTRAINT "FK_c57b3ee1596e9a00008da082ba1" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+
+}

--- a/libs/common/src/database/migration/1756824608863-ChangePlatformIDColType.ts
+++ b/libs/common/src/database/migration/1756824608863-ChangePlatformIDColType.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ChangePlatformIDColType1756824608863 implements MigrationInterface {
+    name = 'ChangePlatformIDColType1756824608863'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" DROP CONSTRAINT "FK_7affc26f7561a1329f6da0c9ec1"`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" DROP CONSTRAINT "FK_86a2e27320d8434d971ea976a5e"`);
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" DROP CONSTRAINT "FK_64361bc1fa9d5a776432e05d184"`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" DROP CONSTRAINT "FK_54cf8d0f71f944b36489a5242c5"`);
+        await queryRunner.query(`ALTER TABLE "device" DROP CONSTRAINT "FK_a4431527b507da2834b9cd02fc9"`);
+        await queryRunner.query(`ALTER TABLE "platform" ALTER COLUMN "id" DROP DEFAULT`);
+        await queryRunner.query(`DROP SEQUENCE IF EXISTS "platform_id_seq"`);
+        await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pgcrypto`);
+        await queryRunner.query(`ALTER TABLE "platform" ADD COLUMN "old_id" bigint`);
+        await queryRunner.query(`UPDATE "platform" SET old_id = id`);
+        await queryRunner.query(`UPDATE "platform" SET id = ((('x' || substr(encode(digest(name::text, 'sha256'), 'hex'), 1, 8))::bit(32)::bigint) & 4294967295) % 100000000`);
+        await queryRunner.query(`UPDATE "device" d SET platform_id = p.id FROM "platform" p WHERE d.platform_id = p.old_id`);
+        await queryRunner.query(`UPDATE "platform_device_type" pdt SET platform_id = p.id FROM "platform" p WHERE pdt.platform_id = p.old_id`);
+        await queryRunner.query(`UPDATE "offering_tree_policy" otp SET platform_id = p.id FROM "platform" p WHERE otp.platform_id = p.old_id`);
+        await queryRunner.query(`ALTER TABLE "platform" DROP COLUMN "old_id"`);
+        await queryRunner.query(`ALTER TABLE "device" ADD CONSTRAINT "FK_a4431527b507da2834b9cd02fc9" FOREIGN KEY ("platform_id") REFERENCES "platform"("id") ON DELETE SET NULL ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" ADD CONSTRAINT "FK_64361bc1fa9d5a776432e05d184" FOREIGN KEY ("platform_id") REFERENCES "platform"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" ADD CONSTRAINT "FK_7affc26f7561a1329f6da0c9ec1" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" ADD CONSTRAINT "FK_54cf8d0f71f944b36489a5242c5" FOREIGN KEY ("platform_id") REFERENCES "platform"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" ADD CONSTRAINT "FK_86a2e27320d8434d971ea976a5e" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "platform_device_type" DROP CONSTRAINT "FK_86a2e27320d8434d971ea976a5e"`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" DROP CONSTRAINT "FK_54cf8d0f71f944b36489a5242c5"`);
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" DROP CONSTRAINT "FK_7affc26f7561a1329f6da0c9ec1"`);
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" DROP CONSTRAINT "FK_64361bc1fa9d5a776432e05d184"`);
+        await queryRunner.query(`ALTER TABLE "device" DROP CONSTRAINT "FK_a4431527b507da2834b9cd02fc9"`);
+        await queryRunner.query(`ALTER TABLE "platform" ADD COLUMN "old_id" bigint`);
+        await queryRunner.query(`UPDATE "platform" SET old_id = id`);
+        await queryRunner.query(`CREATE SEQUENCE IF NOT EXISTS "platform_id_seq" OWNED BY "platform"."id"`);
+        await queryRunner.query(`WITH cte AS (SELECT id AS old_id, ROW_NUMBER() OVER (ORDER BY old_id) AS rn FROM "platform") UPDATE "platform" p SET id = cte.rn FROM cte WHERE p.id = cte.old_id`);
+        await queryRunner.query(`SELECT setval('platform_id_seq',(SELECT COALESCE(MAX(id),0) FROM "platform"))`);
+        await queryRunner.query(`UPDATE "device" d SET platform_id = p.id FROM "platform" p WHERE d.platform_id = p.old_id`);
+        await queryRunner.query(`UPDATE "platform_device_type" pdt SET platform_id = p.id FROM "platform" p WHERE pdt.platform_id = p.old_id`);
+        await queryRunner.query(`UPDATE "offering_tree_policy" otp SET platform_id = p.id FROM "platform" p WHERE otp.platform_id = p.old_id`);
+        await queryRunner.query(`ALTER TABLE "platform" DROP COLUMN "old_id"`);
+        await queryRunner.query(`ALTER TABLE "device" ADD CONSTRAINT "FK_a4431527b507da2834b9cd02fc9" FOREIGN KEY ("platform_id") REFERENCES "platform"("id") ON DELETE SET NULL ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" ADD CONSTRAINT "FK_54cf8d0f71f944b36489a5242c5" FOREIGN KEY ("platform_id") REFERENCES "platform"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" ADD CONSTRAINT "FK_64361bc1fa9d5a776432e05d184" FOREIGN KEY ("platform_id") REFERENCES "platform"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "platform_device_type" ADD CONSTRAINT "FK_86a2e27320d8434d971ea976a5e" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE NO ACTION ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "offering_tree_policy" ADD CONSTRAINT "FK_7affc26f7561a1329f6da0c9ec1" FOREIGN KEY ("device_type_id") REFERENCES "device_type"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+}

--- a/libs/common/src/dto/error/dto/error.ts
+++ b/libs/common/src/dto/error/dto/error.ts
@@ -40,7 +40,11 @@ export enum ErrorCode {
 
   // devices
   DEVICE_NOT_FOUND = "DEVICE.notFound",
-  
+
+  // device type
+  DT_NOT_FOUND = "DEVICE_TYPE.notFound",
+  DT_ALREADY_EXISTS = "DEVICE_TYPE.alreadyExists",
+
   // groups
   GROUP_NOT_FOUND = "GROUP.notFound",
   GROUP_NOT_ALLOWED_TO_ADD = "GROUP.notAllowedToAdd",
@@ -84,6 +88,9 @@ export class ErrorDto {
       "`PLATFORM.notFound`: Platform with given id or name not found.<br/>" +
 
       "`DEVICE.notFound`: Device with given id not found.<br/>" +
+
+      "`DT_NOT_FOUND`: Device type with given id not found.<br/>" +
+      "`DT_ALREADY_EXISTS`: Device type with given name already exists.<br/>" +
 
       "`GROUP_NOT_FOUND`: Group with the given id was not found.<br/>" +
       "`GROUP_NOT_ALLOWED_TO_ADD`: Not allowed to add to the group, see message for cause.<br/>" +

--- a/libs/common/src/dto/error/dto/error.ts
+++ b/libs/common/src/dto/error/dto/error.ts
@@ -35,15 +35,12 @@ export enum ErrorCode {
   MAP_AREA_TOO_LARGE = "MAP.areaTooLarge",
   MAP_AREA_TOO_SMALL = "MAP.areaTooSmall",
 
-  // offering
-  PLATFORM_NOT_FOUND = "PLATFORM.notFound",
-
   // devices
   DEVICE_NOT_FOUND = "DEVICE.notFound",
-
-  // device type
-  DT_NOT_FOUND = "DEVICE_TYPE.notFound",
-  DT_ALREADY_EXISTS = "DEVICE_TYPE.alreadyExists",
+  DEVICE_DT_NOT_FOUND = "DEVICE_TYPE.notFound",
+  DEVICE_DT_ALREADY_EXISTS = "DEVICE_TYPE.alreadyExists",
+  DEVICE_PLATFORM_NOT_FOUND = "DEVICE_PLATFORM.notFound",
+  DEVICE_PLATFORM_ALREADY_EXISTS = "DEVICE_PLATFORM.alreadyExists",
 
   // groups
   GROUP_NOT_FOUND = "GROUP.notFound",
@@ -85,12 +82,12 @@ export class ErrorDto {
       "`MAP.areaTooLarge`: Area too large to distribute, reduce request size and try again <br /> " +
       "`MAP.areaTooSmall`: Area too small to distribute, increase request size and try again . " +
 
-      "`PLATFORM.notFound`: Platform with given id or name not found.<br/>" +
 
       "`DEVICE.notFound`: Device with given id not found.<br/>" +
-
-      "`DT_NOT_FOUND`: Device type with given id not found.<br/>" +
-      "`DT_ALREADY_EXISTS`: Device type with given name already exists.<br/>" +
+      "`DEVICE_DT_NOT_FOUND`: Device type with given id not found.<br/>" +
+      "`DEVICE_DT_ALREADY_EXISTS`: Device type with given name already exists.<br/>" +
+      "`DEVICE_PLATFORM.notFound`: Platform with given id or name not found.<br/>" +
+      "`DEVICE_PLATFORM_ALREADY_EXISTS`: Platform with given name already exists.<br/>" +
 
       "`GROUP_NOT_FOUND`: Group with the given id was not found.<br/>" +
       "`GROUP_NOT_ALLOWED_TO_ADD`: Not allowed to add to the group, see message for cause.<br/>" +


### PR DESCRIPTION
This pull request introduces a significant change to how IDs are generated and managed for `PlatformEntity` and `DeviceTypeEntity` in the hierarchy service. Instead of using auto-incremented IDs, IDs are now deterministically generated by hashing the entity name, which helps avoid collisions and improves referential integrity. The migration script updates the database schema and data accordingly. Additionally, error handling is standardized to use custom exceptions with error codes.

**ID Generation and Migration**

* Changed `id` fields in `DeviceTypeEntity` and `PlatformEntity` from auto-increment (`@PrimaryGeneratedColumn`) to explicit integer primary keys (`@PrimaryColumn`) that are generated by hashing the entity name. [[1]](diffhunk://#diff-17802e7a4face98b5ffeb644b887085cdb65c552848bef57d38bf7475d968f0eL1-R9) [[2]](diffhunk://#diff-c03ee3116e7493355a3246069a0e100ff67a67e79ae79f85a28020bfe61ec7d5L8-R8)
* Added logic in `HierarchyService` to hash the name and generate a unique numeric ID for platforms and device types, including collision handling. [[1]](diffhunk://#diff-8b81e88a37dd36e5b7a00d683d7ab5cfab9b0c5698162d3662ef659a16bc10afR33-R45) [[2]](diffhunk://#diff-8b81e88a37dd36e5b7a00d683d7ab5cfab9b0c5698162d3662ef659a16bc10afR127-R140)
* Added a new migration (`1756818420639-ChabgeDevieTypeIDColType.ts`) to update the database: drops foreign keys and indexes, changes ID values to hashed values, updates child tables, and restores constraints and indexes. Includes rollback logic to restore auto-increment IDs if needed.